### PR TITLE
CI: add workflow_dispatch and lint artifacts

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up MSVC x64 build environment
         uses: ilammy/msvc-dev-cmd@v1
@@ -29,7 +29,7 @@ jobs:
         run: ren build\windows-msvc-x64-release\sim.exe sim-x64.exe
 
       - name: Upload x64 binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binary-x64 # Explicit artifact name
           path: build\windows-msvc-x64-release\sim-x64.exe # Explicit file path to upload
@@ -39,7 +39,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up MSVC x86 build environment
         uses: ilammy/msvc-dev-cmd@v1
@@ -54,7 +54,7 @@ jobs:
         run: ren build\windows-msvc-x86-release\sim.exe sim-x86.exe
 
       - name: Upload x86 binary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binary-x86 # Explicit artifact name
           path: build\windows-msvc-x86-release\sim-x86.exe # Explicit file path to upload
@@ -65,19 +65,19 @@ jobs:
     runs-on: ubuntu-latest # ubuntu-latest is sufficient for creating the release
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create a directory for binaries
         run: mkdir release_binaries
 
       - name: Download x64 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: binary-x64
           path: release_binaries
 
       - name: Download x86 binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: binary-x86
           path: release_binaries

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,6 +1,7 @@
 name: Code Quality Check
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -35,8 +36,10 @@ jobs:
 
       - name: Check code formatting for compliance
         run: |
+          New-Item -ItemType Directory -Path ci-artifacts -Force | Out-Null
           $files = Get-ChildItem -Path src -Recurse -Include *.cpp,*.h
-          clang-format --dry-run --Werror --style=file $files
+          clang-format --dry-run --Werror --style=file $files 2>&1 | Tee-Object -FilePath ci-artifacts/clang-format.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
         shell: pwsh # Use PowerShell for Get-ChildItem
 
       - name: Set up MSVC build environment for the script
@@ -45,6 +48,14 @@ jobs:
           arch: x64
 
       - name: Run clang-tidy
-        shell: cmd
+        shell: pwsh
         run: |
-          scripts\lint.bat
+          cmd /c scripts\lint.bat 2>&1 | Tee-Object -FilePath ci-artifacts/clang-tidy.log
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Upload lint artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-quality-artifacts-${{ github.run_id }}
+          path: ci-artifacts/

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify clang-tools installation
         run: |
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload lint artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: code-quality-artifacts-${{ github.run_id }}
           path: ci-artifacts/


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` to `Code Quality Check`
- persist `clang-format` and `clang-tidy` outputs as workflow artifacts

## Why
- allows manual pre-check runs in forks via UI/CLI
- makes failures easier to debug by keeping lint logs attached to the run

## Details
- `workflow_dispatch` added under `on:`
- `clang-format` output is captured to `ci-artifacts/clang-format.log`
- `clang-tidy` output is captured to `ci-artifacts/clang-tidy.log`
- artifacts are uploaded with `if: always()`